### PR TITLE
read2() is now compatible with parallel reads [flow.parallel()]

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,6 @@ function read2(stream) {
   function read () {
     var data = stream.read()
     if(data !== null && cbs.length) {
-      console.log("da", data)
       output.push([null, data]);
       waiting = false;
       drain();


### PR DESCRIPTION
read2 got stuck when tried to consume several concurrent reads.
