### PR TITLE
fix: remove unnecessary code and dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-var pull = require('pull-stream/pull')
 var looper = require('looper')
 
 function destroy (stream) {
@@ -70,19 +69,6 @@ function write(read, stream, cb) {
   })
 }
 
-function first (emitter, events, handler) {
-  function listener (val) {
-    events.forEach(function (e) {
-      emitter.removeListener(e, listener)
-    })
-    handler(val)
-  }
-  events.forEach(function (e) {
-    emitter.on(e, listener)
-  })
-  return emitter
-}
-
 function read2(stream) {
   var ended = false, waiting = false
   var _cb
@@ -120,7 +106,6 @@ function read2(stream) {
 function read1(stream) {
   var buffer = [], cbs = [], ended, paused = false
 
-  var draining
   function drain() {
     while((buffer.length || ended) && cbs.length)
       cbs.shift()(buffer.length ? null : ended, buffer.shift())

--- a/package.json
+++ b/package.json
@@ -8,15 +8,15 @@
     "url": "git://github.com/dominictarr/stream-to-pull-stream.git"
   },
   "dependencies": {
-    "looper": "^3.0.0",
-    "pull-stream": "^3.2.3"
+    "looper": "^3.0.0"
   },
   "devDependencies": {
     "pull-cat": "^1.1.11",
     "pull-hang": "0.0.0",
     "pull-split": "^0.2.0",
     "tape": "^4.5.1",
-    "through": "~2.3.4"
+    "through": "~2.3.4",
+    "pull-stream": "^3.2.3"
   },
   "scripts": {
     "test": "set -e; for t in test/*.js; do node $t; done"


### PR DESCRIPTION
Seems like some cruft left over from an older revision of the code.

- `pull-stream` as a dependency is now only used in tests, so moved to devDependencies
- `draining` variable is unused
- `first` function is unused